### PR TITLE
fix: fully state dependencies

### DIFF
--- a/minspan.py
+++ b/minspan.py
@@ -166,7 +166,7 @@ def nnz(S):
     if hasattr(S, "nnz"):
         return S.nnz
     if isinstance(S, matrix):
-        return S.nonzero()[0].shape[1]
+        return S.nonzero()[0].shape[0]
     total = S != 0
     for i in range(len(S.shape)):
         total = sum(total)

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,21 @@ setup(
     name="minspan",
     version="0.1.0",
     py_modules=["minspan"],
-    install_requires=["cobra"],
+    install_requires=[
+        "cobra<=0.9.0",
+        "numpy",
+        "scipy<1.0.0",
+        "sympy"
+    ],
     author="Ali Ebrahim and Aarash Bordbar",
     author_email="aebrahim@ucsd.edu",
     url="https://github.com/SBRG/minspan",
     license="MIT",
-    classifiers=["License :: OSI Approved :: MIT License",
-                 "Intended Audience :: Science/Research",
-                 ],
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Intended Audience :: Science/Research",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7"
+    ]
 )


### PR DESCRIPTION
It seems the Python code of minspan hasn't been touched in a long time. I will update cobrapy soon, getting rid of the old solvers and `ArrayBasedModel`. This PR will pin your dependencies to something where the test code still passes so I hope that any Python users will not be affected by the changes to cobrapy.

There are other functions now such as `create_stoichiometric_matrix` but we can cross that bridge when there is a desire to update this package.

Changes:

* explicitly state top level dependencies and pin versions where
  necessary
* make Python 2 only compatibility explicit
* fix bug in `nnz` since `matrix.nonzero()` always returns a pair of 1D
  arrays